### PR TITLE
Added the 'Mining Type' field to the creation form

### DIFF
--- a/app/controllers/coins_controller.rb
+++ b/app/controllers/coins_controller.rb
@@ -1,5 +1,6 @@
 class CoinsController < ApplicationController
   before_action :set_coin, only: %i[ show edit update destroy ]
+  before_action :set_mining_type, only: [:new, :edit, :update, :create]
 
   # GET /coins or /coins.json
   def index
@@ -58,6 +59,11 @@ class CoinsController < ApplicationController
   end
 
   private
+
+    def set_mining_type
+      @mining_type_options = MiningType.all.pluck(:description, :id)
+    end
+
     # Use callbacks to share common setup or constraints between actions.
     def set_coin
       @coin = Coin.find(params[:id])
@@ -65,6 +71,6 @@ class CoinsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def coin_params
-      params.require(:coin).permit(:description, :acronym, :image_url)
+      params.require(:coin).permit(:description, :acronym, :image_url, :mining_type_id)
     end
 end

--- a/app/views/coins/_form.html.erb
+++ b/app/views/coins/_form.html.erb
@@ -28,6 +28,12 @@
   </div>
 
   <div>
+   <%= form.label :mining_type_id, style: "display: block" %>
+    <%= form.select("mining_type_id", @mining_type_options, {include_blank: "Select one"}) %>
+  </div>
+
+
+  <div>
     <%= form.submit %>
   </div>
 <% end %>


### PR DESCRIPTION
I've created another field on the db called "mining_type" that communicates with the "MiningType" model, so the field "mining_type_id" was missing on the form, thus, I couldn't create more coins.

Added this param as a requirement to make the creation of the coin possible, built a controller method to talk to the model (I made the view directly communicate with the model but i've changed that after noticing it).